### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ An awesome list of events and fellowship opportunities for computer science stud
  * [Stanford ACM ICPC](https://github.com/jaehyunp/stanfordacm) - Stanford [Notebook](https://github.com/jaehyunp/stanfordacm/blob/master/notebook.pdf) provides printable templates usable during online/on-site contests.
  * [Exercism](http://exercism.io/) - Solve programming challenges from your terminal.
  * [DailyCodingProblem](https://www.dailycodingproblem.com/) - Get exceptionally good at coding interviews by solving one problem every day.
- * [acmp.ru](acmp.ru) - Russian programming contests
+ * [acmp.ru](http://acmp.ru) - Russian programming contests
  * [Timus Online Judge](http://acm.timus.ru/?locale=en) - Programming contests with online judging system.
- * [DMOJ: Modern Online Judge](dmoj.ca) - contest platform and archive of programming problems
+ * [DMOJ: Modern Online Judge](https://dmoj.ca) - contest platform and archive of programming problems
 
  ### Web Development
 


### PR DESCRIPTION
Some links didn't have the `http://` prefix and behaved like relative links. Fixed:
- acmp.ru
- dmoj.ca