### PR TITLE
Add new platform to MOOCs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ __Recon__
 * [Sololearn](https://www.sololearn.com/) - Learn coding from the ground up for free!! (also available on android)
 * [Y Combinator](https://www.insidesherpa.com/virtual-internships/prototype/oRMogWRHeewqHzA7u/College-students%3A-Learn-how-to-work-at-a-YC-startup-) - Learn how engineering works at a Y Combinator startup
 * [MOOC.fi](https://www.mooc.fi/en) - Free courses from the University of Helsinki's Department of Computer Science.
+* [LabEx](https://labex.io) - Free and paid hands-on labs for Linux, DevOps, Cybersecurity, and Programming.
 
 ## Fellowships/Scholarships
 


### PR DESCRIPTION
Add LabEx to MOOCs section. 

I work at LabEx, a unique learning platform that has offered thousands of free and paid hands-on labs over the past 7 years, enabling users to acquire new CS skills through practical, real-world experience. 

I appreciate this great list of resources. Please let me know if any changes are needed.