### PR TITLE
Add TutorialSearch to MOOCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ __Recon__
 
 [Back to Top](#contents)
 
-* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+* [TutorialSearch](https://tutorialsearch.io/browse/science/computer-science) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 * [Udacity](http://udacity.com) - Free and paid online classes.
 * [Coursera](http://coursera.org) - Courses from schools and universities like Stanford and Yale.
 * [Udemy](http://udemy.com) - Online learning and teaching platform.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ __Recon__
 
 [Back to Top](#contents)
 
+* [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 * [Udacity](http://udacity.com) - Free and paid online classes.
 * [Coursera](http://coursera.org) - Courses from schools and universities like Stanford and Yale.
 * [Udemy](http://udemy.com) - Online learning and teaching platform.


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *MOOCs* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/science/computer-science) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/science/computer-science) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.